### PR TITLE
Fix offset of twac

### DIFF
--- a/contracts/PythOracle.sol
+++ b/contracts/PythOracle.sol
@@ -63,10 +63,10 @@ contract PythOracle {
 
     // Get the twap, twac and last slot an update was made
     function getTimeWeightedInfo() public view returns (int64 twap, uint64 twac, uint64 last_slot) {
-        bytes memory accData = QueryAccount.data(priceAccount, 32, 64);
+        bytes memory accData = QueryAccount.data(priceAccount, 32, 48);
         last_slot = readLittleEndianUnsigned64(accData.toUint64(0));
         twap = readLittleEndianSigned64(accData.toUint64(16));
-        twac = readLittleEndianUnsigned64(accData.toUint64(24));
+        twac = readLittleEndianUnsigned64(accData.toUint64(40));
     }
 
     // Get the last successful price update


### PR DESCRIPTION
The EMA struct (of twap) consists of 3 u64 = 24 bytes, so the offset is 16+24 = 40.
Also we don't need to read the full EMA struct, the first field is all we need, thus only reading 48 bytes.